### PR TITLE
Rename default git branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS Cloudfront Invalidation Buildkite Plugin
 
-![Build status](https://badge.buildkite.com/bc93ae8fdb633030909b9c42fc0a89a6712d4407c387209706.svg?branch=master)
+![Build status](https://badge.buildkite.com/bc93ae8fdb633030909b9c42fc0a89a6712d4407c387209706.svg?branch=main)
 [![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE)
 
 A [Buildkite plugin] that invalidates AWS Cloudfront caches.


### PR DESCRIPTION
#### Context

To be more welcoming and inclusive, the default git branch has been renamed to `main`.

#### Change

Update the build status badge to consider builds on the `main` branch.