### PR TITLE
Add an until loop to retry cache invalidation, with exponential backoff

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -15,7 +15,7 @@ distribution_id="$(plugin_read_config DISTRIBUTION_ID)"
 # This tries to create an invalidation with an empty path list
 #
 # - If we have permission to call create-invalidation for this distribution,
-#   we'll recieve an InvalidArgument error, and we can procede with a real invalidation
+#   we'll recieve an InvalidArgument error, and we can proceed with a real invalidation
 # - Otherwise, either an AccessDenied or NoSuchDistribution error are the most likely results,
 #   in which case we exit with error
 if ! aws cloudfront create-invalidation --distribution-id "$distribution_id" --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' 2>&1 | grep InvalidArgument > /dev/null; then

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -17,8 +17,10 @@ while read -r line ; do
 done <<< "$(plugin_read_list PATHS)"
 
 echo "~~~ :cloudfront: Creating Cloudfront invalidation for distribution $distribution_id on paths" "${paths[@]}"
-aws cloudfront create-invalidation \
-  --distribution-id "$distribution_id" \
-  --paths "${paths[@]}" \
-  --query Invalidation.Id \
-  --output text
+SLEEP_PERIOD=15
+until aws cloudfront create-invalidation --distribution-id "$distribution_id" --paths "${paths[@]}" --query Invalidation.Id --output text
+do
+  echo "Invalidation failed - retrying in ${SLEEP_PERIOD}"
+  sleep ${SLEEP_PERIOD}
+  SLEEP_PERIOD=$((SLEEP_PERIOD+SLEEP_PERIOD))
+done

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,12 +10,19 @@ if [[ ${BUILDKITE_COMMAND_EXIT_STATUS:-0} != '0' ]]; then
   exit 0
 fi
 
-if ! aws sts get-caller-identity; then
-  echo "Unable to invalidate cloudfront cache: credentials missing"
+distribution_id="$(plugin_read_config DISTRIBUTION_ID)"
+
+# This tries to create an invalidation with an empty path list
+#
+# - If we have permission to call create-invalidation for this distribution,
+#   we'll recieve an InvalidArgument error, and we can procede with a real invalidation
+# - Otherwise, either an AccessDenied or NoSuchDistribution error are the most likely results,
+#   in which case we exit with error
+if ! aws cloudfront create-invalidation --distribution-id "$distribution_id" --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' 2>&1 | grep InvalidArgument > /dev/null; then
+  echo "Unable to invalidate cloudfront cache: create-invalidation not possible for distribution ($distribution_id) with current credentials"
   exit 1
 fi
 
-distribution_id="$(plugin_read_config DISTRIBUTION_ID)"
 paths=()
 while read -r line ; do
   [[ -n "$line" ]] && paths+=("$line")
@@ -33,5 +40,4 @@ do
   echo "Invalidation failed - retrying in ${SLEEP_PERIOD}"
   sleep ${SLEEP_PERIOD}
   SLEEP_PERIOD=$((SLEEP_PERIOD+SLEEP_PERIOD))
-
 done

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,6 +10,11 @@ if [[ ${BUILDKITE_COMMAND_EXIT_STATUS:-0} != '0' ]]; then
   exit 0
 fi
 
+if ! aws sts get-caller-identity; then
+  echo "Unable to invalidate cloudfront cache: credentials missing"
+  exit 1
+fi
+
 distribution_id="$(plugin_read_config DISTRIBUTION_ID)"
 paths=()
 while read -r line ; do
@@ -18,9 +23,15 @@ done <<< "$(plugin_read_list PATHS)"
 
 echo "~~~ :cloudfront: Creating Cloudfront invalidation for distribution $distribution_id on paths" "${paths[@]}"
 SLEEP_PERIOD=15
+PERIOD_LIMIT=480
 until aws cloudfront create-invalidation --distribution-id "$distribution_id" --paths "${paths[@]}" --query Invalidation.Id --output text
 do
+  if [ $SLEEP_PERIOD == $PERIOD_LIMIT ]; then
+    echo "Maximum retries reached - giving up..."
+    exit 1
+  fi
   echo "Invalidation failed - retrying in ${SLEEP_PERIOD}"
   sleep ${SLEEP_PERIOD}
   SLEEP_PERIOD=$((SLEEP_PERIOD+SLEEP_PERIOD))
+
 done

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -10,10 +10,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_DISTRIBUTION_ID=test_id
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS=/something/*
 
-  stub grep "InvalidArgument : echo credential success"
-
   stub aws \
-    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo InvalidArgument" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* --query Invalidation.Id --output text : echo cloudfront invalidated"
 
   run $PWD/hooks/post-command
@@ -28,10 +26,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_DISTRIBUTION_ID=test_id
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_0=/something/*
 
-  stub grep "InvalidArgument : echo credential success"
-
   stub aws \
-    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo InvalidArgument" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* --query Invalidation.Id --output text : echo cloudfront invalidated"
 
   run $PWD/hooks/post-command
@@ -47,10 +43,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_0=/something/*
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_1=/something-else/*
 
-  stub grep "InvalidArgument : echo credential success"
-
   stub aws \
-    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo InvalidArgument" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* /something-else/* --query Invalidation.Id --output text : echo cloudfront invalidated"
 
   run $PWD/hooks/post-command
@@ -70,16 +64,14 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
 }
 
-@test "Retries when insuccessfully submitting a validation request" {
+@test "Retries after unsuccessfully submitting a validation request" {
   export BUILDKITE_COMMAND_EXIT_STATUS=0
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_DISTRIBUTION_ID=test_id
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_0=/something/*
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_1=/something-else/*
 
-  stub grep "InvalidArgument : echo credential success"
-
   stub aws \
-    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo InvalidArgument" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* /something-else/* --query Invalidation.Id --output text : return 1" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* /something-else/* --query Invalidation.Id --output text : echo cloudfront invalidated"
   stub sleep "15 : echo sleeping"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -10,8 +10,10 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_DISTRIBUTION_ID=test_id
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS=/something/*
 
+  stub grep "InvalidArgument : echo credential success"
+
   stub aws \
-    "sts get-caller-identity : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* --query Invalidation.Id --output text : echo cloudfront invalidated"
 
   run $PWD/hooks/post-command
@@ -26,8 +28,10 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_DISTRIBUTION_ID=test_id
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_0=/something/*
 
+  stub grep "InvalidArgument : echo credential success"
+
   stub aws \
-    "sts get-caller-identity : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* --query Invalidation.Id --output text : echo cloudfront invalidated"
 
   run $PWD/hooks/post-command
@@ -43,8 +47,10 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_0=/something/*
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_1=/something-else/*
 
+  stub grep "InvalidArgument : echo credential success"
+
   stub aws \
-    "sts get-caller-identity : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* /something-else/* --query Invalidation.Id --output text : echo cloudfront invalidated"
 
   run $PWD/hooks/post-command
@@ -70,8 +76,10 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_0=/something/*
   export BUILDKITE_PLUGIN_AWS_CLOUDFRONT_INVALIDATION_PATHS_1=/something-else/*
 
+  stub grep "InvalidArgument : echo credential success"
+
   stub aws \
-    "sts get-caller-identity : echo checking creds" \
+    "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo checking creds" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* /something-else/* --query Invalidation.Id --output text : return 1" \
     "cloudfront create-invalidation --distribution-id test_id --paths /something/* /something-else/* --query Invalidation.Id --output text : echo cloudfront invalidated"
   stub sleep "15 : echo sleeping"
@@ -88,7 +96,7 @@ load '/usr/local/lib/bats/load.bash'
 @test "Stops executing if a credential problem is detected" {
   export BUILDKITE_COMMAND_EXIT_STATUS=0
 
-  stub aws "sts get-caller-identity : return 1"
+  stub aws "cloudfront create-invalidation --distribution-id test_id --invalidation-batch 'Paths={Quantity=0,Items=[]},CallerReference=cloudfront-invalidation-buildkite-plugin' : echo AccessDenied" \
 
   run $PWD/hooks/post-command
 


### PR DESCRIPTION
Subsequent to a couple of reports of issues on buildkite pipelines, this change should prevent broken builds resulting from failed cloudfront invalidation requests.